### PR TITLE
fix: resources block now displays correctly with <100% zoom in browser

### DIFF
--- a/src/components/home/Resources.tsx
+++ b/src/components/home/Resources.tsx
@@ -11,9 +11,9 @@ const Resources = () => {
         Resources & Documentation
       </h2>
 
-      <div className="mx-auto h-auto w-[90%] lg:w-auto rounded-[30px] bg-slate-900 p-3 lg:p-5 shadow-2xl lg:h-[40rem] lg:max-w-5xl">
-        <div className="grid h-full w-full grid-cols-1 gap-4 overflow-hidden rounded-2xl bg-vrun-neutral-1 dark:bg-slate-900">
-          <div className="flex flex-col items-center justify-center max-w-3xl w-full sm:flex-row sm:flex-wrap">
+      <div className="mx-auto h-auto w-[90%] lg:w-auto rounded-[30px] bg-slate-900 p-3 lg:p-5 shadow-2xl lg:max-w-5xl">
+        <div className="grid w-full grid-cols-1 gap-4 overflow-hidden rounded-2xl bg-vrun-neutral-1 dark:bg-slate-900">
+          <div className="grid grid-cols-1 md:grid-cols-2 max-w-3xl w-full">
             <Link href="/account">
               <Card>
                 <CardIcon>
@@ -45,7 +45,6 @@ const Resources = () => {
             <a
               href="https://docs.rocketpool.net/overview/contracts-integrations"
               target="_blank"
-              className="lg:self-start mt-3"
             >
               <Card>
                 <CardIcon>
@@ -68,7 +67,6 @@ const Resources = () => {
             <a
               href="https://github.com/stakevrun/db"
               target="_blank"
-              className="lg:self-start mt-3"
             >
               <Card>
                 <CardIcon>

--- a/src/components/layout/Card.tsx
+++ b/src/components/layout/Card.tsx
@@ -8,7 +8,7 @@ type CardProps = {
 export const Card = ({ children, className = "" }: CardProps) => {
   return (
     <div
-      className={`group m-4 p-6 text-left text-inherit no-underline border border-slate-200 dark:border-none rounded-lg transition-colors duration-150 ease-in-out hover:bg-slate-100/60 dark:bg-slate-800 dark:hover:bg-slate-700/60 active:border-sky-500 max-w-[350px] ${className}`}
+      className={`group m-4 p-6 text-left text-inherit no-underline border border-slate-200 dark:border-none rounded-lg transition-colors duration-150 ease-in-out hover:bg-slate-100/60 dark:bg-slate-800 dark:hover:bg-slate-700/60 active:border-sky-500 ${className}`}
     >
       {children}
     </div>


### PR DESCRIPTION
Removed some fixed widths and heights and changed from `flex` class usage to `grid`.
This allows the `flexbox` to do it's job when resizing the website using the browser's zoom function.